### PR TITLE
Fixes CellProfiler issue #1824 - turn numeric rows into A-Z + test

### DIFF
--- a/src/main/java/org/cellprofiler/imageset/WellMetadataExtractor.java
+++ b/src/main/java/org/cellprofiler/imageset/WellMetadataExtractor.java
@@ -53,6 +53,15 @@ public class WellMetadataExtractor implements
 			}
 		}
 		if ((wellRow != null) && (wellColumn != null)) {
+			/*
+			 * For Phenix, well row can be numeric
+			 */
+			if (wellRow.matches("\\d+")) {
+				final int rowIndex = Integer.parseInt(wellRow);
+				if ((rowIndex > 0) && (rowIndex <= 24))  {
+					wellRow = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".substring(rowIndex-1, rowIndex);
+				}
+			}
 			return Collections.singletonMap(WELL, StringCache.intern(wellRow + wellColumn));
 		}
 		return emptyMap;

--- a/src/test/java/org/cellprofiler/imageset/TestWellMetadataExtractor.java
+++ b/src/test/java/org/cellprofiler/imageset/TestWellMetadataExtractor.java
@@ -47,6 +47,9 @@ public class TestWellMetadataExtractor {
 			}
 		}
 		testWellCase(new String [][] {{ "rOW", "A" }, {"cOl", "01"}}, "A01");
+		testWellCase(new String [][] {{ "row", "02"}, {"col", "04"}}, "B04");
+		testWellCase(new String [][] {{ "row", "00"}, {"col", "01"}}, "0001");
+		testWellCase(new String [][] {{ "row", "25"}, {"col", "01"}}, "2501");
 	}
 	@Test
 	public void testMaybeYouNeedThis() {


### PR DESCRIPTION
Actually, it fixes https://github.com/CellProfiler/CellProfiler/issues/1677, not 1824. The Perkin-Elmer Phenix (sic) has numeric well rows that should be converted to A-Z.
@dlogan @0x00B1 please review
