### PR TITLE
Fixed CellProfiler issue #1843 - handle non-capturing exprs

### DIFF
--- a/src/main/java/org/cellprofiler/imageset/MetadataUtils.java
+++ b/src/main/java/org/cellprofiler/imageset/MetadataUtils.java
@@ -158,7 +158,9 @@ public class MetadataUtils {
 			if (keys != null) {
 				if (matcher.group(6) != null) {
 					keys.add(matcher.group(6));
-				} else {
+				} else if (! pattern.substring(matcher.end(), matcher.end()+1).equals("?")) {
+					// If (? ... ), then it is non-capturing.
+					// If (...), then is capturing and needs to be skipped.
 					keys.add(null);
 				}
 			}

--- a/src/main/java/org/cellprofiler/imageset/filter/Filter.java
+++ b/src/main/java/org/cellprofiler/imageset/filter/Filter.java
@@ -77,6 +77,10 @@ public class Filter<C> {
 			throw new BadFilterExpressionException(reason, expression, this.offset + offset);
 		}
 	}
+	/**
+	 * Find backslash-escaped characters in a quote-escaped string. 
+	 */
+	static private Pattern quoteEscapePattern = Pattern.compile("\\\\(.)");
 	static private int nCachedEntries = 100;
 	final static private Map<Class<?>, Map<String, Filter<?>>> filterCache = new HashMap<Class<?>, Map<String, Filter<?>>>();
 	final static public Random random = new Random(0);
@@ -251,10 +255,6 @@ public class Filter<C> {
 	 * capturing it.
 	 */
 	static private Pattern literalPattern = Pattern.compile("\"((?:[^\\\\\"]|(?:\\\\.))*)\" ?");
-	/**
-	 * Find backslash-escaped characters in a quote-escaped string. 
-	 */
-	static private Pattern quoteEscapePattern = Pattern.compile("\\\\(.)");
 	/*
 	 * Parentheses expressions are separated by a space. A series of parentheses
 	 * expressions is terminated either by end of expression or the end parenthesis

--- a/src/test/java/org/cellprofiler/imageset/TestRegexpMetadataExtractor.java
+++ b/src/test/java/org/cellprofiler/imageset/TestRegexpMetadataExtractor.java
@@ -83,4 +83,17 @@ public class TestRegexpMetadataExtractor {
 				"Plate_A01.png",
 				new String[][] {{ "Well", "A01"}});
 	}
+	@Test
+	public void testNonCapturing() {
+		// Regression test of issue 1843
+		testSomething(
+				"^(?P<Experiment>[0-9]+).+?(?=_p[0-9])_p(?P<Position>[0-9]+)t(?P<Time>[0-9]+)c(?P<ChannelNumber>[0-9]+)",
+				"121201_RCM_HBC_cell density_complete_p01t00001c01.tif",
+				new String [][] {
+						{ "Experiment", "121201" },
+						{ "Position", "01" },
+						{ "Time", "00001" },
+						{ "ChannelNumber", "01" }
+				});
+	}
 }


### PR DESCRIPTION
https://github.com/CellProfiler/CellProfiler/issues/1843

The problem was that Java 6 doesn't have named regexp captures (but Java 7 does if someone wants to update the code), so I have to hand parse the regexp to pull out the named captures and convert them to regular parentheses ordering captures. Then there's issue of having parentheses w/o named capture in the Python regexp. That worked too. But I didn't account for non-capturing regexps not being captured (ok I hope you are completely confused and just plain believe me at this point).
