### PR TITLE
Spring dependency fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,15 @@
                 </exclusion>
                 <exclusion>
                     <groupId>org.springframework</groupId>
-                    <artifactId>*</artifactId>
+                    <artifactId>spring-beans</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-context</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-orm</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.springframework.security</groupId>

--- a/src/test/java/org/cellprofiler/ome/TestOmero.java
+++ b/src/test/java/org/cellprofiler/ome/TestOmero.java
@@ -13,6 +13,7 @@ package org.cellprofiler.ome;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.lang.reflect.InvocationTargetException;
@@ -52,6 +53,8 @@ public class TestOmero {
         method = klass.getMethod("unwrap", omero.RType.class);
         assertNotNull(method);
         object = method.invoke(null, object);
+        assertNotNull(object);
+        assertEquals(1, object);
     }
 
 }

--- a/src/test/java/org/cellprofiler/ome/TestOmero.java
+++ b/src/test/java/org/cellprofiler/ome/TestOmero.java
@@ -15,6 +15,9 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertNotNull;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 
 /**
  * Tests that OMERO is available.
@@ -31,6 +34,24 @@ public class TestOmero {
     @Test
     public void testOmeroReaderOnClassPath() throws ClassNotFoundException {
         assertNotNull(Class.forName("loci.ome.io.OmeroReader"));
+    }
+
+    @Test
+    public void testOmeroRtypeUsage()
+            throws ClassNotFoundException, InstantiationException,
+                IllegalAccessException, NoSuchMethodException,
+                SecurityException, IllegalArgumentException,
+                InvocationTargetException {
+        Class<?> klass = Class.forName("omero.rtypes");
+        assertNotNull(klass);
+        Method method = klass.getMethod("rtype", Object.class);
+        assertNotNull(method);
+        Object object = method.invoke(null, 1);
+        assertNotNull(object);
+
+        method = klass.getMethod("unwrap", omero.RType.class);
+        assertNotNull(method);
+        object = method.invoke(null, object);
     }
 
 }


### PR DESCRIPTION
Follow on from #34 which fixes an overeager dependency exclusion related to Spring.

`omero.rtypes` uses Spring (`spring-core`) to perform various reflection related tasks via `org.springframework.util.ReflectionUtils`. Usage of static methods such as `omero.rtypes.unwrap()` will fail with class not found exceptions without these changes.

/cc @0x00b1, @mcquin, @emilroz, @joshmoore, @jburel, @sbesson