### PR TITLE
Restore net.imagej:ij1-patcher dependency for CP 2.2.x compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,6 +287,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>net.imagej</groupId>
+                <artifactId>ij1-patcher</artifactId>
+                <version>0.12.6</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>


### PR DESCRIPTION
CellProfiler 2.2.x maintains a hard dependency link on the ImageJ 1.x
updater through the use of the `-javaagent` command line argument
passed to the JVM.  While the updater does not appear to be used, class
not found exceptions or problems with missing JAR manifest attributes
will result in CellProfiler 2.2.x not starting up.

This commit restores compatibility with pre-3.0.0 versions of
CellProfiler.  These versions will install the latest version of this
dependency when installed via source or in development mode.